### PR TITLE
QUA-1940 Fix error leading to segmentation fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
 DOCS         = $(wildcard doc/*.md)
 TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --inputdir=test --load-language=plpgsql
+REGRESS_OPTS = --inputdir=test
 #
 # Uncoment the MODULES line if you are adding C files
 # to your extention.
@@ -28,8 +28,11 @@ endif
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
-src/pg_rrule.o: CFLAGS += $(shell pkg-config --cflags libical)
+src/pg_rrule.o: CFLAGS += $(shell pkg-config --cflags libical) # for debug: -g3 -ggdb3
 pg_rrule.so: SHLIB_LINK += $(shell pkg-config --libs libical)
+
+# Avoid copying the same file twice
+DATA := $(sort $(DATA))
 
 sql/pg_rrule.sql: sql/pg_rrule.sql.in
 	sed 's,MODULE_PATHNAME,$$libdir/$(@:sql/%.sql=%),g' $< >$@

--- a/pg_rrule.control
+++ b/pg_rrule.control
@@ -1,5 +1,5 @@
 # pg_rrule extension
 comment = 'RRULE field type for PostgreSQL'
-default_version = '0.2.0'
+default_version = '0.3.0'
 relocatable = true
 module_pathname = '$libdir/pg_rrule'

--- a/sql/pg_rrule.sql.in
+++ b/sql/pg_rrule.sql.in
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION rrule_out(rrule)
 CREATE TYPE rrule (
    input = rrule_in,
    output = rrule_out,
-   internallength = 2760 -- TODO: check sizeof(icalrecurrencetype) on 32-bit machine
+   internallength = 2896 -- CRITICAL: Must match the size of 'icalrecurrencetype' in the current version of libical. cf ASSERT in pg_rrule.c
 );
 
 

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,19 +1,18 @@
-\set ECHO 0
-
+\set ECHO errors
 SELECT 'FREQ=WEEKLY;INTERVAL=1;WKST=MO;UNTIL=20200101T045102Z'::rrule;
-              rrule
+               rrule                
 ------------------------------------
  FREQ=WEEKLY;UNTIL=20200101T045102Z
 (1 row)
 
 SELECT get_byday('FREQ=WEEKLY;INTERVAL=1;WKST=MO;UNTIL=20200101T045102Z;BYDAY=MO,TH,SU'::rrule);
- get_byday
+ get_byday 
 -----------
  {2,5,1}
 (1 row)
 
 SELECT get_freq('FREQ=WEEKLY;INTERVAL=1;WKST=MO;UNTIL=20200101T045102Z'::rrule);
- get_freq
+ get_freq 
 ----------
  WEEKLY
 (1 row)
@@ -23,12 +22,13 @@ SELECT * FROM
         get_occurrences('FREQ=WEEKLY;INTERVAL=1;WKST=MO;UNTIL=20200101T045102Z;BYDAY=SA;BYHOUR=10;BYMINUTE=51;BYSECOND=2'::rrule,
             '2019-12-07 10:51:02+00'::timestamp with time zone)
     );
-         unnest
-------------------------
- 2019-12-07 10:51:02+00
- 2019-12-14 10:51:02+00
- 2019-12-21 10:51:02+00
- 2019-12-28 10:51:02+00
+WARNING:  Can't get timezone from current session! Fallback to UTC.
+            unnest            
+------------------------------
+ Sat Dec 07 02:51:02 2019 PST
+ Sat Dec 14 02:51:02 2019 PST
+ Sat Dec 21 02:51:02 2019 PST
+ Sat Dec 28 02:51:02 2019 PST
 (4 rows)
 
 SELECT * FROM
@@ -36,12 +36,28 @@ SELECT * FROM
         get_occurrences('FREQ=WEEKLY;INTERVAL=1;WKST=MO;UNTIL=20200101T045102Z;BYDAY=SA;BYHOUR=10;BYMINUTE=51;BYSECOND=2'::rrule,
             '2019-12-07 10:51:02'::timestamp)
     );
-       unnest
----------------------
- 2019-12-07 10:51:02
- 2019-12-14 10:51:02
- 2019-12-21 10:51:02
- 2019-12-28 10:51:02
+          unnest          
+--------------------------
+ Sat Dec 07 10:51:02 2019
+ Sat Dec 14 10:51:02 2019
+ Sat Dec 21 10:51:02 2019
+ Sat Dec 28 10:51:02 2019
 (4 rows)
+
+WITH occurrences AS (
+    SELECT unnest(
+        get_occurrences(
+           'FREQ=DAILY;BYHOUR=09;'::rrule,
+            '2024-05-25 00:00:00'::timestamp,
+            '2024-05-27 00:00:00'::timestamp
+        )
+    ) as occ
+)
+SELECT * FROM occurrences;
+           occ            
+--------------------------
+ Sat May 25 09:00:00 2024
+ Sun May 26 09:00:00 2024
+(2 rows)
 
 ROLLBACK;

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -1,4 +1,4 @@
-\set ECHO 0
+\set ECHO errors
 BEGIN;
 \i sql/pg_rrule.sql
 \set ECHO all
@@ -20,5 +20,16 @@ SELECT * FROM
         get_occurrences('FREQ=WEEKLY;INTERVAL=1;WKST=MO;UNTIL=20200101T045102Z;BYDAY=SA;BYHOUR=10;BYMINUTE=51;BYSECOND=2'::rrule,
             '2019-12-07 10:51:02'::timestamp)
     );
+
+WITH occurrences AS (
+    SELECT unnest(
+        get_occurrences(
+           'FREQ=DAILY;BYHOUR=09;'::rrule,
+            '2024-05-25 00:00:00'::timestamp,
+            '2024-05-27 00:00:00'::timestamp
+        )
+    ) as occ
+)
+SELECT * FROM occurrences;
 
 ROLLBACK;


### PR DESCRIPTION
- Fixed the error, likely due to a new version of libical with a new size for `icalrecurrencetype`
- Added an `assert(sizeof(struct icalrecurrencetype)==2896);` to protect against future similar problem
- Fixed PG_GETARG_TIMESTAMPTZ -> PG_GETARG_TIMESTAMP in the non TZ version
- Updated the unit-tests for postgres 13